### PR TITLE
feat: implement pager support for view commands

### DIFF
--- a/internal/utils/pager.go
+++ b/internal/utils/pager.go
@@ -1,0 +1,169 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// PagerOptions contains options for the pager
+type PagerOptions struct {
+	// Pager command to use (e.g., "less", "more")
+	Pager string
+	// Whether to force pager even if not a TTY
+	Force bool
+	// Whether to disable pager
+	NoPager bool
+}
+
+// ShowInPager displays content using the configured pager
+func ShowInPager(content string, opts *PagerOptions) error {
+	if opts == nil {
+		opts = &PagerOptions{}
+	}
+
+	// Check if pager should be disabled
+	if opts.NoPager {
+		fmt.Print(content)
+		return nil
+	}
+
+	// Check if output is to a TTY (unless forced)
+	if !opts.Force && !isTerminal(os.Stdout) {
+		fmt.Print(content)
+		return nil
+	}
+
+	// Determine pager command
+	pager := opts.Pager
+	if pager == "" {
+		// Check PAGER environment variable
+		pager = os.Getenv("PAGER")
+		if pager == "" {
+			pager = "less"
+		}
+	}
+
+	// Try to run the pager
+	cmd := exec.Command("sh", "-c", pager)
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Set LESS options if using less and not already set
+	if strings.Contains(pager, "less") && os.Getenv("LESS") == "" {
+		cmd.Env = append(os.Environ(), "LESS=FRX")
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		// Fallback to direct output if pager fails
+		fmt.Print(content)
+		// Don't return the error since we successfully displayed the content
+		return nil
+	}
+
+	return nil
+}
+
+// WriteToPager creates a writer that will display content through a pager
+func WriteToPager(opts *PagerOptions) (io.WriteCloser, error) {
+	if opts == nil {
+		opts = &PagerOptions{}
+	}
+
+	// Check if pager should be disabled
+	if opts.NoPager {
+		return &passthroughWriter{w: os.Stdout}, nil
+	}
+
+	// Check if output is to a TTY (unless forced)
+	if !opts.Force && !isTerminal(os.Stdout) {
+		return &passthroughWriter{w: os.Stdout}, nil
+	}
+
+	// Determine pager command
+	pager := opts.Pager
+	if pager == "" {
+		// Check PAGER environment variable
+		pager = os.Getenv("PAGER")
+		if pager == "" {
+			pager = "less"
+		}
+	}
+
+	// Create a buffer to collect output
+	buf := &bytes.Buffer{}
+
+	return &pagerWriter{
+		buf:   buf,
+		pager: pager,
+	}, nil
+}
+
+// pagerWriter collects output and displays it through a pager when closed
+type pagerWriter struct {
+	buf   *bytes.Buffer
+	pager string
+}
+
+func (p *pagerWriter) Write(data []byte) (int, error) {
+	return p.buf.Write(data)
+}
+
+func (p *pagerWriter) Close() error {
+	content := p.buf.String()
+
+	// Try to run the pager
+	cmd := exec.Command("sh", "-c", p.pager)
+	cmd.Stdin = strings.NewReader(content)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Set LESS options if using less and not already set
+	if strings.Contains(p.pager, "less") && os.Getenv("LESS") == "" {
+		cmd.Env = append(os.Environ(), "LESS=FRX")
+	}
+
+	err := cmd.Run()
+	if err != nil {
+		// Fallback to direct output if pager fails
+		fmt.Print(content)
+		// Don't return the error since we successfully displayed the content
+		return nil
+	}
+
+	return nil
+}
+
+// passthroughWriter is a simple writer that passes through to another writer
+type passthroughWriter struct {
+	w io.Writer
+}
+
+func (p *passthroughWriter) Write(data []byte) (int, error) {
+	return p.w.Write(data)
+}
+
+func (p *passthroughWriter) Close() error {
+	return nil
+}
+
+// isTerminal checks if the given file is a terminal
+func isTerminal(f *os.File) bool {
+	if f == nil {
+		return false
+	}
+
+	// Get file info
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+
+	// Check if it's a character device (terminal)
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/utils/pager_test.go
+++ b/internal/utils/pager_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPagerOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    *PagerOptions
+		content string
+	}{
+		{
+			name: "NoPager option",
+			opts: &PagerOptions{
+				NoPager: true,
+			},
+			content: "Test content",
+		},
+		{
+			name: "Custom pager",
+			opts: &PagerOptions{
+				Pager:   "cat",
+				Force:   true,
+			},
+			content: "Test content with custom pager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This test just ensures the function doesn't panic
+			// Actual pager behavior is hard to test in unit tests
+			err := ShowInPager(tt.content, tt.opts)
+			if err != nil {
+				t.Errorf("ShowInPager() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestIsTerminal(t *testing.T) {
+	// Test with stdout (may or may not be a terminal depending on test environment)
+	_ = isTerminal(os.Stdout)
+	
+	// Test with nil
+	if isTerminal(nil) {
+		t.Error("isTerminal(nil) should return false")
+	}
+}


### PR DESCRIPTION
## Summary
- Implements pager support for `bc4 todo view`, `bc4 project view`, `bc4 campfire view`, and `bc4 card view` commands
- Provides full-screen, scrollable viewing experience exactly like `gh issue view`
- Respects user's configured pager preference and PAGER environment variable

## Changes
1. **Created pager utility** (`internal/utils/pager.go`):
   - TTY detection to automatically bypass pager for piped output
   - Support for custom pager commands via config or PAGER env var
   - Automatic fallback to direct output if pager fails
   - Sets `LESS=FRX` for better default experience with less

2. **Updated all view commands**:
   - `cmd/todo/view.go`: Buffer output and display through pager
   - `cmd/project/view.go`: Buffer output and display through pager
   - `cmd/campfire/view.go`: Buffer output and display through pager
   - `cmd/card/view.go`: Buffer output and display through pager (including steps table)

3. **Added `--no-pager` flag** to all view commands to bypass pager when needed

4. **Added tests** for the pager utility to ensure basic functionality

## Test plan
- [x] Build passes (`go build -o bc4`)
- [x] Tests pass (`go test ./...`)
- [x] Code formatted (`go fmt ./...`)
- [x] Static analysis passes (`go vet ./...`)
- [ ] Manual testing of pager with view commands
- [ ] Test --no-pager flag works correctly
- [ ] Test piped output bypasses pager
- [ ] Test PAGER environment variable override

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)