### PR TITLE
feat: implement distribution system with version management and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run tests
+        run: go test -v ./...
+
+      - name: Import GPG key (if available)
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+        continue-on-error: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+
+      - name: Upload assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: bc4-binaries
+          path: dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: ['1.21', '1.22', '1.23']
+        os: [macos-latest, macos-13]  # Test on both Apple Silicon and Intel
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Build
+        run: make build
+
+      - name: Test built binary
+        run: |
+          ./build/bc4 version
+          ./build/bc4 --version
+
+  lint:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ go.work
 
 # Build output
 bc4
+build/
 dist/
 
 # IDE specific files

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -123,10 +123,9 @@ release:
   footer: |
     ## Installation
     
-    ### Homebrew
+    ### Homebrew (Recommended)
     ```bash
-    brew tap needmore/bc4
-    brew install bc4
+    brew install needmore/bc4/bc4
     ```
     
     ### Direct Download
@@ -142,13 +141,25 @@ release:
     sudo mv bc4 /usr/local/bin/
     ```
 
-# Homebrew tap configuration (to be implemented separately)
-# brews:
-#   - name: bc4
-#     tap:
-#       owner: needmore
-#       name: homebrew-bc4
-#     folder: Formula
-#     homepage: "https://github.com/needmore/bc4"
-#     description: "A CLI tool for interacting with Basecamp 4"
-#     license: "MIT"
+# Homebrew tap configuration (same repository)
+brews:
+  - name: bc4
+    tap:
+      owner: needmore
+      name: bc4
+      branch: main
+    folder: Formula
+    homepage: "https://github.com/needmore/bc4"
+    description: "A CLI tool for interacting with Basecamp 4"
+    license: "MIT"
+    
+    # Commit author
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    
+    # Commit message
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    
+    # Skip upload if formula already exists
+    skip_upload: auto

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,154 @@
+# .goreleaser.yml
+# GoReleaser configuration for bc4
+
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+project_name: bc4
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules
+    - go mod tidy
+    # Run tests before building
+    - go test ./...
+
+builds:
+  - id: bc4
+    main: ./main.go
+    binary: bc4
+    
+    # Custom ldflags for version injection
+    ldflags:
+      - -s -w
+      - -X github.com/needmore/bc4/internal/version.Version={{.Version}}
+      - -X github.com/needmore/bc4/internal/version.GitCommit={{.Commit}}
+      - -X github.com/needmore/bc4/internal/version.BuildDate={{.Date}}
+    
+    # Build for macOS only (as requested)
+    goos:
+      - darwin
+    
+    # Build for both Intel and Apple Silicon
+    goarch:
+      - amd64
+      - arm64
+    
+    # Environment variables
+    env:
+      - CGO_ENABLED=0
+    
+    # Build mode
+    mod_timestamp: '{{ .CommitTimestamp }}'
+
+# Create universal binary for macOS
+universal_binaries:
+  - id: bc4-universal
+    ids:
+      - bc4
+    replace: true
+    name_template: "bc4"
+
+archives:
+  - id: bc4-archive
+    builds:
+      - bc4
+    
+    # Archive name template
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    
+    # Use tar.gz for macOS
+    format: tar.gz
+    
+    # Additional files to include
+    files:
+      - LICENSE*
+      - README.md
+      - CHANGELOG.md
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - '^build:'
+      - Merge pull request
+      - Merge remote-tracking branch
+      - Merge branch
+  groups:
+    - title: 'New Features'
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug Fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: 'Performance Improvements'
+      regexp: "^.*perf[(\\w)]*:+.*$"
+      order: 2
+    - title: 'Code Refactoring'
+      regexp: "^.*refactor[(\\w)]*:+.*$"
+      order: 3
+    - title: 'Other Changes'
+      order: 999
+
+release:
+  # GitHub release settings
+  github:
+    owner: needmore
+    name: bc4
+  
+  # Release name template
+  name_template: "{{.ProjectName}} v{{.Version}}"
+  
+  # Disable auto-publishing (can be overridden with --release-notes)
+  draft: false
+  
+  # Add release notes
+  footer: |
+    ## Installation
+    
+    ### Homebrew
+    ```bash
+    brew tap needmore/bc4
+    brew install bc4
+    ```
+    
+    ### Direct Download
+    Download the appropriate archive for your system from the assets below.
+    
+    For macOS:
+    - Intel Macs: `bc4_*_Darwin_x86_64.tar.gz`
+    - Apple Silicon Macs: `bc4_*_Darwin_arm64.tar.gz`
+    
+    Extract and install:
+    ```bash
+    tar -xzf bc4_*.tar.gz
+    sudo mv bc4 /usr/local/bin/
+    ```
+
+# Homebrew tap configuration (to be implemented separately)
+# brews:
+#   - name: bc4
+#     tap:
+#       owner: needmore
+#       name: homebrew-bc4
+#     folder: Formula
+#     homepage: "https://github.com/needmore/bc4"
+#     description: "A CLI tool for interacting with Basecamp 4"
+#     license: "MIT"

--- a/Formula/bc4.rb
+++ b/Formula/bc4.rb
@@ -1,5 +1,5 @@
-# This is a template for the Homebrew formula
-# It should be placed in the homebrew-bc4 repository at Formula/bc4.rb
+# Homebrew formula for bc4
+# This file is automatically updated by the release process
 
 class Bc4 < Formula
   desc "A CLI tool for interacting with Basecamp 4"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,96 @@
+# bc4 Makefile
+
+# Get version from git tag or use dev
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS := -ldflags "-X github.com/needmore/bc4/internal/version.Version=$(VERSION) \
+	-X github.com/needmore/bc4/internal/version.GitCommit=$(COMMIT) \
+	-X github.com/needmore/bc4/internal/version.BuildDate=$(BUILD_DATE)"
+
+# Binary name
+BINARY := bc4
+
+# Build directories
+BUILD_DIR := ./build
+DIST_DIR := ./dist
+
+.PHONY: all build build-all clean test fmt vet lint install version help
+
+# Default target
+all: clean fmt vet test build
+
+# Build for current platform
+build:
+	@echo "Building $(BINARY) $(VERSION) for current platform..."
+	@go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY) .
+
+# Build for all supported platforms
+build-all: clean
+	@echo "Building $(BINARY) $(VERSION) for all platforms..."
+	@mkdir -p $(DIST_DIR)
+	
+	# macOS Intel
+	@echo "Building for darwin/amd64..."
+	@GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-amd64 .
+	
+	# macOS Apple Silicon
+	@echo "Building for darwin/arm64..."
+	@GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY)-darwin-arm64 .
+	
+	# Create universal binary for macOS
+	@echo "Creating universal binary..."
+	@lipo -create -output $(DIST_DIR)/$(BINARY)-darwin-universal \
+		$(DIST_DIR)/$(BINARY)-darwin-amd64 \
+		$(DIST_DIR)/$(BINARY)-darwin-arm64
+
+# Run tests
+test:
+	@echo "Running tests..."
+	@go test -v ./...
+
+# Format code
+fmt:
+	@echo "Formatting code..."
+	@go fmt ./...
+
+# Run go vet
+vet:
+	@echo "Running go vet..."
+	@go vet ./...
+
+# Run linting (requires golangci-lint)
+lint:
+	@echo "Running linters..."
+	@golangci-lint run
+
+# Install binary to GOPATH/bin
+install: build
+	@echo "Installing $(BINARY) to GOPATH/bin..."
+	@go install $(LDFLAGS) .
+
+# Clean build artifacts
+clean:
+	@echo "Cleaning build artifacts..."
+	@rm -rf $(BUILD_DIR) $(DIST_DIR)
+	@go clean
+
+# Show version info
+version:
+	@echo "Version: $(VERSION)"
+	@echo "Commit: $(COMMIT)"
+	@echo "Build Date: $(BUILD_DATE)"
+
+# Show help
+help:
+	@echo "Available targets:"
+	@echo "  make build       - Build for current platform"
+	@echo "  make build-all   - Build for all supported platforms"
+	@echo "  make test        - Run tests"
+	@echo "  make fmt         - Format code"
+	@echo "  make vet         - Run go vet"
+	@echo "  make lint        - Run linters (requires golangci-lint)"
+	@echo "  make install     - Install to GOPATH/bin"
+	@echo "  make clean       - Clean build artifacts"
+	@echo "  make version     - Show version info"
+	@echo "  make help        - Show this help message"

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ A powerful command-line interface for [Basecamp](https://basecamp.com/), inspire
 ### Install with Homebrew (macOS)
 
 ```bash
-brew tap needmore/bc4
-brew install bc4
+brew install needmore/bc4/bc4
 ```
 
 ### Install from source

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,65 +41,33 @@ git push origin v1.0.0
 2. Watch the "Release" workflow
 3. Once completed, check the [Releases page](https://github.com/needmore/bc4/releases)
 
-### 4. Update Homebrew Formula
+### 4. Verify Homebrew Formula Update
 
-After the GitHub release is created:
+GoReleaser will automatically update the Homebrew formula in the `Formula` directory of this repository. After the release workflow completes:
 
-1. Clone the homebrew tap repository (to be created):
+1. Check that the formula was updated:
    ```bash
-   git clone https://github.com/needmore/homebrew-bc4.git
-   cd homebrew-bc4
+   git pull origin main
+   cat Formula/bc4.rb
    ```
 
-2. Update the formula with the new version and SHA256 checksums:
-   ```ruby
-   class Bc4 < Formula
-     desc "A CLI tool for interacting with Basecamp 4"
-     homepage "https://github.com/needmore/bc4"
-     version "1.0.0"
-     
-     on_macos do
-       if Hardware::CPU.arm?
-         url "https://github.com/needmore/bc4/releases/download/v1.0.0/bc4_1.0.0_Darwin_arm64.tar.gz"
-         sha256 "CHECKSUM_HERE"
-       else
-         url "https://github.com/needmore/bc4/releases/download/v1.0.0/bc4_1.0.0_Darwin_x86_64.tar.gz"
-         sha256 "CHECKSUM_HERE"
-       end
-     end
-     
-     def install
-       bin.install "bc4"
-     end
-     
-     test do
-       assert_match "bc4 version", shell_output("#{bin}/bc4 --version")
-     end
-   end
-   ```
+2. The formula should have been automatically updated with the new version and SHA256 checksums.
 
-3. Get checksums from the `checksums.txt` file in the release
-
-4. Test the formula locally:
-   ```bash
-   brew install --build-from-source ./Formula/bc4.rb
-   brew test bc4
-   ```
-
-5. Commit and push the changes:
-   ```bash
-   git add Formula/bc4.rb
-   git commit -m "Update bc4 to v1.0.0"
-   git push origin main
-   ```
+3. If you need to make manual adjustments, you can edit `Formula/bc4.rb` and commit the changes.
 
 ### 5. Test Installation
 
 Test that users can install the new version:
 
 ```bash
+# For first-time installation
+brew install needmore/bc4/bc4
+
+# For updates
 brew update
 brew upgrade bc4
+
+# Verify
 bc4 --version
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,156 @@
+# Releasing bc4
+
+This document describes the process for releasing new versions of bc4.
+
+## Prerequisites
+
+- You must have write access to the bc4 repository
+- Go 1.21 or later installed
+- GoReleaser installed locally (for testing): `brew install goreleaser`
+- GPG key for signing (optional)
+
+## Release Process
+
+### 1. Prepare the Release
+
+1. Ensure all changes for the release are merged to `main`
+2. Run tests locally: `make test`
+3. Update version references if needed (though most are automated)
+
+### 2. Create and Push a Tag
+
+```bash
+# Fetch latest changes
+git checkout main
+git pull origin main
+
+# Create a new tag following semantic versioning
+# For a new release:
+git tag -a v1.0.0 -m "Release v1.0.0"
+
+# For a pre-release:
+git tag -a v1.0.0-beta.1 -m "Pre-release v1.0.0-beta.1"
+
+# Push the tag
+git push origin v1.0.0
+```
+
+### 3. Monitor the Release
+
+1. Go to the [Actions tab](https://github.com/needmore/bc4/actions)
+2. Watch the "Release" workflow
+3. Once completed, check the [Releases page](https://github.com/needmore/bc4/releases)
+
+### 4. Update Homebrew Formula
+
+After the GitHub release is created:
+
+1. Clone the homebrew tap repository (to be created):
+   ```bash
+   git clone https://github.com/needmore/homebrew-bc4.git
+   cd homebrew-bc4
+   ```
+
+2. Update the formula with the new version and SHA256 checksums:
+   ```ruby
+   class Bc4 < Formula
+     desc "A CLI tool for interacting with Basecamp 4"
+     homepage "https://github.com/needmore/bc4"
+     version "1.0.0"
+     
+     on_macos do
+       if Hardware::CPU.arm?
+         url "https://github.com/needmore/bc4/releases/download/v1.0.0/bc4_1.0.0_Darwin_arm64.tar.gz"
+         sha256 "CHECKSUM_HERE"
+       else
+         url "https://github.com/needmore/bc4/releases/download/v1.0.0/bc4_1.0.0_Darwin_x86_64.tar.gz"
+         sha256 "CHECKSUM_HERE"
+       end
+     end
+     
+     def install
+       bin.install "bc4"
+     end
+     
+     test do
+       assert_match "bc4 version", shell_output("#{bin}/bc4 --version")
+     end
+   end
+   ```
+
+3. Get checksums from the `checksums.txt` file in the release
+
+4. Test the formula locally:
+   ```bash
+   brew install --build-from-source ./Formula/bc4.rb
+   brew test bc4
+   ```
+
+5. Commit and push the changes:
+   ```bash
+   git add Formula/bc4.rb
+   git commit -m "Update bc4 to v1.0.0"
+   git push origin main
+   ```
+
+### 5. Test Installation
+
+Test that users can install the new version:
+
+```bash
+brew update
+brew upgrade bc4
+bc4 --version
+```
+
+## Version Numbering
+
+We follow [Semantic Versioning](https://semver.org/):
+
+- `MAJOR.MINOR.PATCH` (e.g., `1.2.3`)
+- Increment MAJOR for breaking changes
+- Increment MINOR for new features
+- Increment PATCH for bug fixes
+
+Pre-release versions:
+- Alpha: `v1.0.0-alpha.1`
+- Beta: `v1.0.0-beta.1`
+- Release Candidate: `v1.0.0-rc.1`
+
+## Troubleshooting
+
+### Release Failed
+
+If the release workflow fails:
+
+1. Check the [Actions logs](https://github.com/needmore/bc4/actions)
+2. Fix any issues
+3. Delete the tag locally and remotely:
+   ```bash
+   git tag -d v1.0.0
+   git push origin :refs/tags/v1.0.0
+   ```
+4. Start the process again
+
+### GoReleaser Issues
+
+Test GoReleaser locally before pushing a tag:
+
+```bash
+# Dry run
+goreleaser release --snapshot --clean
+
+# Check the dist/ directory for output
+ls -la dist/
+```
+
+## Release Checklist
+
+- [ ] All tests passing
+- [ ] CHANGELOG.md updated (if maintaining one)
+- [ ] Version tag created and pushed
+- [ ] GitHub release created successfully
+- [ ] Binaries uploaded to release
+- [ ] Homebrew formula updated
+- [ ] Installation tested via Homebrew
+- [ ] Announcement made (if applicable)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,13 +17,15 @@ import (
 	"github.com/needmore/bc4/internal/config"
 	"github.com/needmore/bc4/internal/factory"
 	"github.com/needmore/bc4/internal/tui"
+	"github.com/needmore/bc4/internal/version"
 )
 
 var cfgFile string
 
 var rootCmd = &cobra.Command{
-	Use:   "bc4",
-	Short: "A CLI tool for interacting with Basecamp 4",
+	Use:     "bc4",
+	Short:   "A CLI tool for interacting with Basecamp 4",
+	Version: version.Get().Version,
 	Long: `bc4 is a command-line interface for Basecamp 4 that allows you to:
 • List and manage projects
 • Create and manage todos
@@ -90,6 +92,9 @@ func init() {
 	// rootCmd.AddCommand(message.NewMessageCmd())
 	rootCmd.AddCommand(campfire.NewCampfireCmd(f))
 	rootCmd.AddCommand(card.NewCardCmd(f))
+
+	// Add version command (doesn't need factory)
+	rootCmd.AddCommand(versionCmd)
 }
 
 func initConfig() {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/needmore/bc4/internal/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	versionDetailed bool
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display version information",
+	Long:  `Display the version of bc4 along with build information.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		info := version.Get()
+
+		// Check if JSON output is requested
+		if viper.GetBool("json") {
+			jsonData, err := json.MarshalIndent(info, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal version info: %w", err)
+			}
+			fmt.Println(string(jsonData))
+			return nil
+		}
+
+		// Check if detailed output is requested
+		if versionDetailed {
+			fmt.Println(info.DetailedString())
+		} else {
+			fmt.Println(info.String())
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	versionCmd.Flags().BoolVarP(&versionDetailed, "detailed", "d", false, "Show detailed version information")
+}

--- a/homebrew-formula-template.rb
+++ b/homebrew-formula-template.rb
@@ -1,0 +1,44 @@
+# This is a template for the Homebrew formula
+# It should be placed in the homebrew-bc4 repository at Formula/bc4.rb
+
+class Bc4 < Formula
+  desc "A CLI tool for interacting with Basecamp 4"
+  homepage "https://github.com/needmore/bc4"
+  license "MIT"  # Update with actual license
+  
+  # Version will be updated by release process
+  version "0.1.0"
+  
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/needmore/bc4/releases/download/v#{version}/bc4_#{version}_Darwin_arm64.tar.gz"
+      sha256 "UPDATE_WITH_ACTUAL_SHA256"
+    else
+      url "https://github.com/needmore/bc4/releases/download/v#{version}/bc4_#{version}_Darwin_x86_64.tar.gz"
+      sha256 "UPDATE_WITH_ACTUAL_SHA256"
+    end
+  end
+  
+  def install
+    bin.install "bc4"
+    
+    # Install shell completions if they exist
+    # bash_completion.install "completions/bc4.bash" if File.exist?("completions/bc4.bash")
+    # zsh_completion.install "completions/_bc4" if File.exist?("completions/_bc4")
+    # fish_completion.install "completions/bc4.fish" if File.exist?("completions/bc4.fish")
+  end
+  
+  def post_install
+    # Ensure config directory exists with correct permissions
+    config_dir = "#{ENV["HOME"]}/.config/bc4"
+    FileUtils.mkdir_p(config_dir) unless File.exist?(config_dir)
+  end
+  
+  test do
+    # Test version output
+    assert_match "bc4 version", shell_output("#{bin}/bc4 --version")
+    
+    # Test help output
+    assert_match "A CLI tool for interacting with Basecamp 4", shell_output("#{bin}/bc4 --help")
+  end
+end

--- a/internal/markdown/converter.go
+++ b/internal/markdown/converter.go
@@ -116,11 +116,11 @@ func (c *converter) postProcessHTML(html string) string {
 	html = regexp.MustCompile(`<!-- [^>]* -->`).ReplaceAllString(html, "")
 
 	// Clean up blockquote formatting
-    html = strings.ReplaceAll(html, "<blockquote>\n", "<blockquote>")
-    html = strings.ReplaceAll(html, "\n</blockquote>", "</blockquote>")
+	html = strings.ReplaceAll(html, "<blockquote>\n", "<blockquote>")
+	html = strings.ReplaceAll(html, "\n</blockquote>", "</blockquote>")
 
-    // Clean up excessive newlines
-    re = regexp.MustCompile(`\n{3,}`)
+	// Clean up excessive newlines
+	re = regexp.MustCompile(`\n{3,}`)
 	html = re.ReplaceAllString(html, "\n\n")
 
 	// Final cleanup - remove newlines within line breaks

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,61 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// These variables are set at build time using ldflags
+var (
+	// Version is the semantic version of bc4
+	Version = "dev"
+
+	// GitCommit is the git commit hash
+	GitCommit = "unknown"
+
+	// BuildDate is the date when the binary was built
+	BuildDate = "unknown"
+
+	// GoVersion is the Go version used to build
+	GoVersion = runtime.Version()
+)
+
+// Info represents version information
+type Info struct {
+	Version   string `json:"version"`
+	GitCommit string `json:"gitCommit"`
+	BuildDate string `json:"buildDate"`
+	GoVersion string `json:"goVersion"`
+	Platform  string `json:"platform"`
+}
+
+// Get returns the version information
+func Get() Info {
+	return Info{
+		Version:   Version,
+		GitCommit: GitCommit,
+		BuildDate: BuildDate,
+		GoVersion: GoVersion,
+		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+// String returns a formatted version string
+func (i Info) String() string {
+	return fmt.Sprintf("bc4 version %s (%s, %s)", i.Version, i.GitCommit, i.BuildDate)
+}
+
+// DetailedString returns a detailed version string
+func (i Info) DetailedString() string {
+	return fmt.Sprintf(`bc4 version %s
+  Commit:     %s
+  Built:      %s
+  Go version: %s
+  Platform:   %s`,
+		i.Version,
+		i.GitCommit,
+		i.BuildDate,
+		i.GoVersion,
+		i.Platform,
+	)
+}


### PR DESCRIPTION
## Summary

This PR implements a complete distribution system for bc4, allowing it to be installed and updated like a real application through Homebrew and direct downloads from GitHub Releases.

## What's Implemented

### Phase 1: Version Management ✅
- Created `internal/version` package with build-time version injection
- Added `bc4 version` command with `--detailed` flag for comprehensive version info
- Added `--version` flag to root command for quick version checks
- Version format: `bc4 version X.Y.Z (commit-hash, build-date)`

### Phase 2: Build System ✅
- Created Makefile with:
  - Build targets for current platform and all macOS architectures
  - Version injection via ldflags
  - Support for Intel (amd64) and Apple Silicon (arm64)
  - Test, format, vet, and lint targets
- Added .goreleaser.yml configuration for:
  - Automated builds for macOS
  - Universal binary creation
  - Changelog generation from conventional commits
  - SHA256 checksums

### Phase 3: GitHub Actions ✅
- Created `.github/workflows/release.yml` for automated releases on version tags
- Created `.github/workflows/test.yml` for CI testing on PRs
- Workflows include:
  - Multi-version Go testing (1.21, 1.22, 1.23)
  - Testing on both Intel and Apple Silicon Macs
  - Linting with golangci-lint
  - Automated release with GoReleaser

### Documentation ✅
- Created RELEASING.md with step-by-step release instructions
- Added homebrew-formula-template.rb for future tap setup
- Updated .gitignore to exclude build artifacts

## Testing

```bash
# Test version command
go run main.go version
go run main.go version --detailed
go run main.go --version

# Test build with version injection
make build
./build/bc4 version

# Test cross-compilation
make build-all
```

## Next Steps (Not in this PR)

1. Create `homebrew-bc4` repository for the Homebrew tap
2. Set up GPG signing for releases (optional)
3. Create first release by tagging (e.g., `v0.1.0`)

## How to Release

Once this is merged:
1. Tag a release: `git tag -a v0.1.0 -m "Initial release"`
2. Push the tag: `git push origin v0.1.0`
3. GitHub Actions will automatically create the release

Fixes #25