### PR TITLE
fix: improve API pagination to show complete todo lists

### DIFF
--- a/internal/api/messages.go
+++ b/internal/api/messages.go
@@ -174,7 +174,9 @@ func (c *Client) ListMessageCategories(ctx context.Context, projectID string, me
 	var categories []MessageCategory
 	path := fmt.Sprintf("/buckets/%s/categories.json?categorizable_type=Message::Board&categorizable_id=%d", projectID, messageBoardID)
 
-	if err := c.Get(path, &categories); err != nil {
+	// Use paginated request to ensure we get all categories
+	pr := NewPaginatedRequest(c)
+	if err := pr.GetAll(path, &categories); err != nil {
 		return nil, fmt.Errorf("failed to list message categories: %w", err)
 	}
 

--- a/internal/api/pagination.go
+++ b/internal/api/pagination.go
@@ -24,7 +24,7 @@ func NewPaginatedRequest(client *Client) *PaginatedRequest {
 
 // GetAll fetches all pages of results from a paginated endpoint
 // The result parameter must be a pointer to a slice
-func (pr *PaginatedRequest) GetAll(path string, result interface{}) error {
+func (pr *PaginatedRequest) GetAll(path string, result any) error {
 	// Validate that result is a pointer to a slice
 	resultType := reflect.TypeOf(result)
 	if resultType.Kind() != reflect.Ptr || resultType.Elem().Kind() != reflect.Slice {
@@ -237,7 +237,7 @@ func parseLinkHeaderEntries(linkHeader string) []LinkEntry {
 			}
 			
 			// Add completed entry
-			if currentEntry != nil && currentEntry.URL != "" {
+			if currentEntry.URL != "" {
 				entries = append(entries, *currentEntry)
 			}
 		} else {
@@ -271,7 +271,7 @@ func extractPathFromURL(absoluteURL string) string {
 // GetPage fetches a single page of results
 // Note: For new code, prefer using GetAll() which handles pagination automatically.
 // This method is kept for backwards compatibility and specific use cases.
-func (pr *PaginatedRequest) GetPage(path string, page int, result interface{}) error {
+func (pr *PaginatedRequest) GetPage(path string, page int, result any) error {
 	// Wait for rate limit
 	pr.rateLimiter.Wait()
 

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -37,11 +37,175 @@ func TestParseNextLinkURL(t *testing.T) {
 			linkHeader: `malformed link header`,
 			expected:   "",
 		},
+		{
+			name:       "unquoted rel parameter",
+			linkHeader: `<https://api.example.com/items?page=2>; rel=next`,
+			expected:   "https://api.example.com/items?page=2",
+		},
+		{
+			name:       "quoted parameter with comma inside",
+			linkHeader: `<https://api.example.com/search?q=hello,world>; title="Items, Page 2"; rel="next"`,
+			expected:   "https://api.example.com/search?q=hello,world",
+		},
+		{
+			name:       "multiple rels in one parameter",
+			linkHeader: `<https://api.example.com/page2>; rel="next last"`,
+			expected:   "https://api.example.com/page2",
+		},
+		{
+			name:       "case insensitive rel matching",
+			linkHeader: `<https://api.example.com/page2>; rel="NEXT"`,
+			expected:   "https://api.example.com/page2",
+		},
+		{
+			name:       "complex real-world example",
+			linkHeader: `<https://3.basecampapi.com/999999999/buckets/123/todos.json?page=1>; rel="first", <https://3.basecampapi.com/999999999/buckets/123/todos.json?page=2>; rel="prev", <https://3.basecampapi.com/999999999/buckets/123/todos.json?page=4>; rel="next", <https://3.basecampapi.com/999999999/buckets/123/todos.json?page=10>; rel="last"`,
+			expected:   "https://3.basecampapi.com/999999999/buckets/123/todos.json?page=4",
+		},
+		{
+			name:       "extra whitespace handling",
+			linkHeader: `  <https://api.example.com/page2>  ;  rel="next"  ,  <https://api.example.com/page3>  ;  rel="last"  `,
+			expected:   "https://api.example.com/page2",
+		},
+		{
+			name:       "no angle brackets (malformed but graceful)",
+			linkHeader: `rel="next"`,
+			expected:   "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseNextLinkURL(tt.linkHeader)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseLinkHeaderEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected []LinkEntry
+	}{
+		{
+			name:   "single link",
+			header: `<https://api.example.com/page2>; rel="next"`,
+			expected: []LinkEntry{
+				{
+					URL: "https://api.example.com/page2",
+					Params: map[string]string{
+						"rel": "next",
+					},
+				},
+			},
+		},
+		{
+			name:   "multiple parameters",
+			header: `<https://api.example.com/page2>; rel="next"; title="Next Page"; type="text/html"`,
+			expected: []LinkEntry{
+				{
+					URL: "https://api.example.com/page2",
+					Params: map[string]string{
+						"rel":   "next",
+						"title": "Next Page",
+						"type":  "text/html",
+					},
+				},
+			},
+		},
+		{
+			name:   "quoted parameter with comma",
+			header: `<https://api.example.com/search?q=hello,world>; title="Items, Page 2"`,
+			expected: []LinkEntry{
+				{
+					URL: "https://api.example.com/search?q=hello,world",
+					Params: map[string]string{
+						"title": "Items, Page 2",
+					},
+				},
+			},
+		},
+		{
+			name:   "multiple links",
+			header: `<https://api.example.com/page1>; rel="first", <https://api.example.com/page3>; rel="next"`,
+			expected: []LinkEntry{
+				{
+					URL: "https://api.example.com/page1",
+					Params: map[string]string{
+						"rel": "first",
+					},
+				},
+				{
+					URL: "https://api.example.com/page3",
+					Params: map[string]string{
+						"rel": "next",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseLinkHeaderEntries(tt.header)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLinkEntry_HasRelation(t *testing.T) {
+	tests := []struct {
+		name     string
+		entry    LinkEntry
+		relation string
+		expected bool
+	}{
+		{
+			name: "single quoted relation",
+			entry: LinkEntry{
+				Params: map[string]string{"rel": "next"},
+			},
+			relation: "next",
+			expected: true,
+		},
+		{
+			name: "multiple relations",
+			entry: LinkEntry{
+				Params: map[string]string{"rel": "next last"},
+			},
+			relation: "next",
+			expected: true,
+		},
+		{
+			name: "case insensitive",
+			entry: LinkEntry{
+				Params: map[string]string{"rel": "NEXT"},
+			},
+			relation: "next",
+			expected: true,
+		},
+		{
+			name: "no matching relation",
+			entry: LinkEntry{
+				Params: map[string]string{"rel": "first"},
+			},
+			relation: "next",
+			expected: false,
+		},
+		{
+			name: "no rel parameter",
+			entry: LinkEntry{
+				Params: map[string]string{"title": "test"},
+			},
+			relation: "next",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.entry.hasRelation(tt.relation)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -228,9 +228,39 @@ func TestExtractPathFromURL(t *testing.T) {
 			expected:    "/buckets/987654321/todolists/111/todos.json?page=2",
 		},
 		{
+			name:        "basecamp URL with port",
+			absoluteURL: "https://3.basecampapi.com:443/999999999/buckets/123/todos.json?page=2",
+			expected:    "/buckets/123/todos.json?page=2",
+		},
+		{
+			name:        "basecamp URL without query params",
+			absoluteURL: "https://3.basecampapi.com/999999999/buckets/123/todolists/456/todos.json",
+			expected:    "/buckets/123/todolists/456/todos.json",
+		},
+		{
+			name:        "basecamp URL with complex query params",
+			absoluteURL: "https://3.basecampapi.com/999999999/buckets/123/todos.json?page=2&limit=50&completed=true",
+			expected:    "/buckets/123/todos.json?page=2&limit=50&completed=true",
+		},
+		{
+			name:        "basecamp URL with fragment (should be ignored)",
+			absoluteURL: "https://3.basecampapi.com/999999999/buckets/123/todos.json?page=2#section",
+			expected:    "/buckets/123/todos.json?page=2",
+		},
+		{
 			name:        "already relative path",
 			absoluteURL: "/buckets/123/todos.json",
 			expected:    "/buckets/123/todos.json",
+		},
+		{
+			name:        "relative path with query",
+			absoluteURL: "/buckets/123/todos.json?page=2",
+			expected:    "/buckets/123/todos.json?page=2",
+		},
+		{
+			name:        "non-basecamp URL (fallback behavior)",
+			absoluteURL: "https://api.example.com/v1/items?page=2",
+			expected:    "/v1/items?page=2",
 		},
 		{
 			name:        "malformed URL",
@@ -238,9 +268,24 @@ func TestExtractPathFromURL(t *testing.T) {
 			expected:    "",
 		},
 		{
+			name:        "URL with invalid characters",
+			absoluteURL: "https://invalid url with spaces",
+			expected:    "",
+		},
+		{
 			name:        "empty URL",
 			absoluteURL: "",
 			expected:    "",
+		},
+		{
+			name:        "URL with encoded characters",
+			absoluteURL: "https://3.basecampapi.com/999999999/buckets/123/todos.json?search=hello%20world&page=2",
+			expected:    "/buckets/123/todos.json?search=hello%20world&page=2",
+		},
+		{
+			name:        "basecamp URL with non-standard path structure (fallback)",
+			absoluteURL: "https://3.basecampapi.com/nonstandard/path?page=2",
+			expected:    "/nonstandard/path?page=2",
 		},
 	}
 

--- a/internal/api/pagination_test.go
+++ b/internal/api/pagination_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNextLinkURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		linkHeader string
+		expected   string
+	}{
+		{
+			name:       "simple next link",
+			linkHeader: `<https://3.basecampapi.com/999999999/buckets/2085958496/messages.json?page=4>; rel="next"`,
+			expected:   "https://3.basecampapi.com/999999999/buckets/2085958496/messages.json?page=4",
+		},
+		{
+			name:       "multiple links with next",
+			linkHeader: `<https://3.basecampapi.com/999999999/buckets/123/todos.json?page=1>; rel="first", <https://3.basecampapi.com/999999999/buckets/123/todos.json?page=3>; rel="next"`,
+			expected:   "https://3.basecampapi.com/999999999/buckets/123/todos.json?page=3",
+		},
+		{
+			name:       "no next link",
+			linkHeader: `<https://3.basecampapi.com/999999999/buckets/123/todos.json?page=1>; rel="first"`,
+			expected:   "",
+		},
+		{
+			name:       "empty link header",
+			linkHeader: "",
+			expected:   "",
+		},
+		{
+			name:       "malformed link header",
+			linkHeader: `malformed link header`,
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseNextLinkURL(tt.linkHeader)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractPathFromURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		absoluteURL string
+		expected    string
+	}{
+		{
+			name:        "basecamp API URL",
+			absoluteURL: "https://3.basecampapi.com/999999999/buckets/2085958496/messages.json?page=4",
+			expected:    "/buckets/2085958496/messages.json?page=4",
+		},
+		{
+			name:        "todo list URL",
+			absoluteURL: "https://3.basecampapi.com/123456789/buckets/987654321/todolists/111/todos.json?page=2",
+			expected:    "/buckets/987654321/todolists/111/todos.json?page=2",
+		},
+		{
+			name:        "already relative path",
+			absoluteURL: "/buckets/123/todos.json",
+			expected:    "/buckets/123/todos.json",
+		},
+		{
+			name:        "malformed URL",
+			absoluteURL: "not-a-url",
+			expected:    "",
+		},
+		{
+			name:        "empty URL",
+			absoluteURL: "",
+			expected:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractPathFromURL(tt.absoluteURL)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes issue #55 where todo lists were only showing ~25 results due to incorrect pagination handling.

## Root Cause

The pagination logic was manually constructing page URLs with `?page=N` parameters instead of properly following Basecamp's RFC5988 Link headers. Basecamp uses variable page sizes (15, 30, 50, 100+ results per page) and provides the exact next page URL in the Link header.

## Key Changes

- **🔧 Fixed pagination logic**: Now properly parses and follows Link headers with `rel="next"` 
- **📝 Added helper functions**: `parseNextLinkURL()` and `extractPathFromURL()` for robust Link header handling
- **🧪 Comprehensive tests**: Added test coverage for Link header parsing and URL extraction
- **🔍 Enhanced message categories**: Updated `ListMessageCategories` to use paginated requests
- **📚 Improved documentation**: Added comments explaining Basecamp's pagination approach

## Technical Details

### Before
```go
// Manual page construction - unreliable
paginatedPath = fmt.Sprintf("%s?page=%d", path, page)
hasNextPage = strings.Contains(linkHeader, `rel="next"`)
```

### After  
```go
// Proper RFC5988 Link header following
nextURL := parseNextLinkURL(linkHeader)
currentPath = extractPathFromURL(nextURL)
```

## Testing

- ✅ All existing tests pass
- ✅ New pagination tests verify Link header parsing
- ✅ URL extraction handles various Basecamp API URL formats
- ✅ No regressions in API functionality

## Benefits

- **Complete results**: Todo lists now show all items, not just first ~25
- **Reliable pagination**: Follows Basecamp's official pagination mechanism  
- **Better performance**: Respects Basecamp's variable page sizes and rate limiting
- **Future-proof**: Will work correctly with API changes to pagination URLs

Fixes #55

🤖 Generated with [Claude Code](https://claude.ai/code)