### PR TITLE
feat: add document support for Basecamp API (#43)

### DIFF
--- a/cmd/document/create.go
+++ b/cmd/document/create.go
@@ -1,0 +1,142 @@
+package document
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/needmore/bc4/internal/api"
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/needmore/bc4/internal/markdown"
+	"github.com/needmore/bc4/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newCreateCmd(f *factory.Factory) *cobra.Command {
+	var (
+		title   string
+		content string
+		draft   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create [project]",
+		Short: "Create a new document",
+		Long: `Create a new document in a project's document vault.
+
+You can provide document content in several ways:
+  - Interactively (default)
+  - Via --content flag
+  - Via stdin: echo "content" | bc4 document create [project] --title "Title"
+  - From file: cat document.md | bc4 document create [project] --title "Title"`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Apply project override if specified
+			if len(args) > 0 {
+				f = f.WithProject(args[0])
+			}
+
+			// Get API client from factory
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			// Get resolved project ID
+			projectID, err := f.ProjectID()
+			if err != nil {
+				return err
+			}
+
+			// Get the vault for the project
+			vault, err := client.GetVault(f.Context(), projectID)
+			if err != nil {
+				return err
+			}
+
+			// Check if stdin has data
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				// Data is being piped in
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("failed to read from stdin: %w", err)
+				}
+				content = strings.TrimSpace(string(data))
+
+				// Title is required when using stdin
+				if title == "" {
+					return fmt.Errorf("--title is required when piping content via stdin")
+				}
+			} else if content == "" {
+				// No stdin and no content flag, use interactive mode
+				if title == "" {
+					if err := huh.NewInput().
+						Title("Document title").
+						Placeholder("What's this document about?").
+						Value(&title).
+						Run(); err != nil {
+						return err
+					}
+				}
+
+				if err := huh.NewText().
+					Title("Document content").
+					Placeholder("Write your document in Markdown...").
+					Lines(15).
+					Value(&content).
+					Run(); err != nil {
+					return err
+				}
+			}
+
+			// Validate required fields
+			if title == "" {
+				return fmt.Errorf("document title is required")
+			}
+			if content == "" {
+				return fmt.Errorf("document content is required")
+			}
+
+			// Convert markdown to rich text
+			converter := markdown.NewConverter()
+			richContent, err := converter.MarkdownToRichText(content)
+			if err != nil {
+				return fmt.Errorf("failed to convert markdown: %w", err)
+			}
+
+			// Create the document
+			req := api.DocumentCreateRequest{
+				Title:   title,
+				Content: richContent,
+				Status:  "active",
+			}
+
+			if draft {
+				req.Status = "draft"
+			}
+
+			document, err := client.CreateDocument(f.Context(), projectID, vault.ID, req)
+			if err != nil {
+				return err
+			}
+
+			// Output
+			if ui.IsTerminal(os.Stdout) {
+				fmt.Printf("✓ Created document #%d: %s\n", document.ID, document.Title)
+			} else {
+				fmt.Println(document.ID)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&title, "title", "t", "", "Document title")
+	cmd.Flags().StringVarP(&content, "content", "c", "", "Document content (markdown supported)")
+	cmd.Flags().BoolVarP(&draft, "draft", "d", false, "Create as draft")
+
+	return cmd
+}

--- a/cmd/document/document.go
+++ b/cmd/document/document.go
@@ -1,0 +1,24 @@
+package document
+
+import (
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/spf13/cobra"
+)
+
+// NewDocumentCmd creates a new document command
+func NewDocumentCmd(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "document",
+		Short:   "Work with Basecamp documents",
+		Long:    `Create, edit and view documents in Basecamp projects.`,
+		Aliases: []string{"documents", "doc", "docs"},
+	}
+
+	// Add subcommands
+	cmd.AddCommand(newListCmd(f))
+	cmd.AddCommand(newCreateCmd(f))
+	cmd.AddCommand(newViewCmd(f))
+	cmd.AddCommand(newEditCmd(f))
+
+	return cmd
+}

--- a/cmd/document/edit.go
+++ b/cmd/document/edit.go
@@ -1,0 +1,165 @@
+package document
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/needmore/bc4/internal/api"
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/needmore/bc4/internal/markdown"
+	"github.com/needmore/bc4/internal/parser"
+	"github.com/needmore/bc4/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func newEditCmd(f *factory.Factory) *cobra.Command {
+	var (
+		title   string
+		content string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "edit [document-id|url]",
+		Short: "Edit an existing document",
+		Long: `Edit an existing document.
+
+You can provide updated content in several ways:
+  - Interactively (default)
+  - Via --content flag
+  - Via stdin: cat updated.md | bc4 document edit [document-id]`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get API client from factory
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			var documentID int64
+			var projectID string
+
+			// Parse the argument - could be a URL or ID
+			if parser.IsBasecampURL(args[0]) {
+				parsed, err := parser.ParseBasecampURL(args[0])
+				if err != nil {
+					return fmt.Errorf("invalid Basecamp URL: %w", err)
+				}
+				if parsed.ResourceType != parser.ResourceTypeDocument {
+					return fmt.Errorf("URL is not a document URL: %s", args[0])
+				}
+				documentID = parsed.ResourceID
+				projectID = strconv.FormatInt(parsed.ProjectID, 10)
+			} else {
+				// It's just an ID, we need the project ID from config
+				documentID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid document ID: %s", args[0])
+				}
+				projectID, err = f.ProjectID()
+				if err != nil {
+					return err
+				}
+			}
+
+			// Get the existing document
+			document, err := client.GetDocument(f.Context(), projectID, documentID)
+			if err != nil {
+				return err
+			}
+
+			// Check if stdin has data
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				// Data is being piped in
+				data, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return fmt.Errorf("failed to read from stdin: %w", err)
+				}
+				content = strings.TrimSpace(string(data))
+			} else if content == "" && title == "" {
+				// No stdin and no flags, use interactive mode
+				// Convert existing rich text back to markdown for editing
+				converter := markdown.NewConverter()
+				existingMarkdown, err := converter.RichTextToMarkdown(document.Content)
+				if err != nil {
+					// If conversion fails, use the raw content
+					existingMarkdown = document.Content
+				}
+
+				// Edit title
+				newTitle := document.Title
+				if err := huh.NewInput().
+					Title("Document title").
+					Value(&newTitle).
+					Run(); err != nil {
+					return err
+				}
+				if newTitle != document.Title {
+					title = newTitle
+				}
+
+				// Edit content
+				newContent := existingMarkdown
+				if err := huh.NewText().
+					Title("Document content").
+					Lines(15).
+					Value(&newContent).
+					Run(); err != nil {
+					return err
+				}
+				if newContent != existingMarkdown {
+					content = newContent
+				}
+			}
+
+			// Build update request
+			req := api.DocumentUpdateRequest{}
+			hasUpdate := false
+
+			if title != "" {
+				req.Title = title
+				hasUpdate = true
+			}
+
+			if content != "" {
+				// Convert markdown to rich text
+				converter := markdown.NewConverter()
+				richContent, err := converter.MarkdownToRichText(content)
+				if err != nil {
+					return fmt.Errorf("failed to convert markdown: %w", err)
+				}
+				req.Content = richContent
+				hasUpdate = true
+			}
+
+			if !hasUpdate {
+				fmt.Println("No changes made")
+				return nil
+			}
+
+			// Update the document
+			updated, err := client.UpdateDocument(f.Context(), projectID, documentID, req)
+			if err != nil {
+				return err
+			}
+
+			// Output
+			if ui.IsTerminal(os.Stdout) {
+				fmt.Printf("✓ Updated document #%d: %s\n", updated.ID, updated.Title)
+			} else {
+				fmt.Println(updated.ID)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&title, "title", "t", "", "New document title")
+	cmd.Flags().StringVarP(&content, "content", "c", "", "New document content (markdown supported)")
+
+	return cmd
+}

--- a/cmd/document/list.go
+++ b/cmd/document/list.go
@@ -1,0 +1,83 @@
+package document
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/needmore/bc4/internal/ui"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newListCmd(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list [project]",
+		Short: "List documents",
+		Long:  `List all documents in a project's document vault.`,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Apply project override if specified
+			if len(args) > 0 {
+				f = f.WithProject(args[0])
+			}
+
+			// Get API client from factory
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			// Get resolved project ID
+			projectID, err := f.ProjectID()
+			if err != nil {
+				return err
+			}
+
+			// Get the vault for the project
+			vault, err := client.GetVault(f.Context(), projectID)
+			if err != nil {
+				return err
+			}
+
+			// List documents
+			documents, err := client.ListDocuments(f.Context(), projectID, vault.ID)
+			if err != nil {
+				return err
+			}
+
+			// Output format
+			if viper.GetBool("json") {
+				return json.NewEncoder(os.Stdout).Encode(documents)
+			}
+
+			// Terminal output
+			if len(documents) == 0 {
+				fmt.Println("No documents found in this project's vault.")
+				return nil
+			}
+
+			// Display documents
+			for _, doc := range documents {
+				if ui.IsTerminal(os.Stdout) {
+					fmt.Printf("📄 %s (#%d)\n", doc.Title, doc.ID)
+					fmt.Printf("   Created: %s by %s\n", doc.CreatedAt.Format("2006-01-02 15:04"), doc.Creator.Name)
+					if doc.UpdatedAt.After(doc.CreatedAt) {
+						fmt.Printf("   Updated: %s\n", doc.UpdatedAt.Format("2006-01-02 15:04"))
+					}
+					if doc.CommentsCount > 0 {
+						fmt.Printf("   Comments: %d\n", doc.CommentsCount)
+					}
+					fmt.Println()
+				} else {
+					fmt.Printf("%d\t%s\n", doc.ID, doc.Title)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/document/view.go
+++ b/cmd/document/view.go
@@ -1,0 +1,107 @@
+package document
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/needmore/bc4/internal/markdown"
+	"github.com/needmore/bc4/internal/parser"
+	"github.com/needmore/bc4/internal/ui"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func newViewCmd(f *factory.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "view [document-id|url]",
+		Short: "View a document",
+		Long:  `View a specific document by ID or URL.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get API client from factory
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+
+			var documentID int64
+			var projectID string
+
+			// Parse the argument - could be a URL or ID
+			if parser.IsBasecampURL(args[0]) {
+				parsed, err := parser.ParseBasecampURL(args[0])
+				if err != nil {
+					return fmt.Errorf("invalid Basecamp URL: %w", err)
+				}
+				if parsed.ResourceType != parser.ResourceTypeDocument {
+					return fmt.Errorf("URL is not a document URL: %s", args[0])
+				}
+				documentID = parsed.ResourceID
+				projectID = strconv.FormatInt(parsed.ProjectID, 10)
+			} else {
+				// It's just an ID, we need the project ID from config
+				documentID, err = strconv.ParseInt(args[0], 10, 64)
+				if err != nil {
+					return fmt.Errorf("invalid document ID: %s", args[0])
+				}
+				projectID, err = f.ProjectID()
+				if err != nil {
+					return err
+				}
+			}
+
+			// Get the document
+			document, err := client.GetDocument(f.Context(), projectID, documentID)
+			if err != nil {
+				return err
+			}
+
+			// Output format
+			if viper.GetBool("json") {
+				return json.NewEncoder(os.Stdout).Encode(document)
+			}
+
+			// Terminal output
+			if ui.IsTerminal(os.Stdout) {
+				fmt.Printf("📄 %s (#%d)\n", document.Title, document.ID)
+				fmt.Printf("Created: %s by %s\n", document.CreatedAt.Format("2006-01-02 15:04"), document.Creator.Name)
+				if document.UpdatedAt.After(document.CreatedAt) {
+					fmt.Printf("Updated: %s\n", document.UpdatedAt.Format("2006-01-02 15:04"))
+				}
+				if document.CommentsCount > 0 {
+					fmt.Printf("Comments: %d\n", document.CommentsCount)
+				}
+				fmt.Printf("Status: %s\n", document.Status)
+				fmt.Println()
+				fmt.Println("Content:")
+				fmt.Println("─────────")
+
+				// Try to convert rich text back to markdown for better display
+				converter := markdown.NewConverter()
+				markdownContent, err := converter.RichTextToMarkdown(document.Content)
+				if err != nil {
+					// If conversion fails, show raw content
+					fmt.Println(document.Content)
+				} else {
+					fmt.Println(markdownContent)
+				}
+			} else {
+				// Convert to markdown for non-terminal output
+				converter := markdown.NewConverter()
+				markdownContent, err := converter.RichTextToMarkdown(document.Content)
+				if err != nil {
+					fmt.Println(document.Content)
+				} else {
+					fmt.Println(markdownContent)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/needmore/bc4/cmd/auth"
 	"github.com/needmore/bc4/cmd/campfire"
 	"github.com/needmore/bc4/cmd/card"
+	"github.com/needmore/bc4/cmd/document"
 	"github.com/needmore/bc4/cmd/message"
 	"github.com/needmore/bc4/cmd/project"
 	"github.com/needmore/bc4/cmd/todo"
@@ -100,6 +101,7 @@ func init() {
 	rootCmd.AddCommand(project.NewProjectCmd(f))
 	rootCmd.AddCommand(todo.NewTodoCmd(f))
 	rootCmd.AddCommand(message.NewMessageCmd(f))
+	rootCmd.AddCommand(document.NewDocumentCmd(f))
 	rootCmd.AddCommand(campfire.NewCampfireCmd(f))
 	rootCmd.AddCommand(card.NewCardCmd(f))
 

--- a/internal/api/documents.go
+++ b/internal/api/documents.go
@@ -1,0 +1,160 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Vault represents a Basecamp document vault
+type Vault struct {
+	ID             int64     `json:"id"`
+	Title          string    `json:"title"`
+	Name           string    `json:"name"`
+	Status         string    `json:"status"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	DocumentsURL   string    `json:"documents_url"`
+	URL            string    `json:"url"`
+	DocumentsCount int       `json:"documents_count"`
+	Bucket         struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+		Type string `json:"type"`
+	} `json:"bucket"`
+	Creator Person `json:"creator"`
+}
+
+// Document represents a Basecamp document
+type Document struct {
+	ID        int64     `json:"id"`
+	Title     string    `json:"title"`
+	Content   string    `json:"content"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Creator   Person    `json:"creator"`
+	Parent    struct {
+		ID    int64  `json:"id"`
+		Title string `json:"title"`
+		Type  string `json:"type"`
+		URL   string `json:"url"`
+	} `json:"parent"`
+	CommentsCount    int    `json:"comments_count"`
+	VisibleToClients bool   `json:"visible_to_clients"`
+	URL              string `json:"url"`
+}
+
+// DocumentCreateRequest represents the payload for creating a new document
+type DocumentCreateRequest struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+	Status  string `json:"status,omitempty"` // draft or active
+}
+
+// DocumentUpdateRequest represents the payload for updating a document
+type DocumentUpdateRequest struct {
+	Title   string `json:"title,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// GetVault returns the document vault for a project
+func (c *Client) GetVault(ctx context.Context, projectID string) (*Vault, error) {
+	// First get the project to find its vault
+	project, err := c.GetProject(ctx, projectID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get project tools/features
+	path := fmt.Sprintf("/projects/%d.json", project.ID)
+
+	var projectData struct {
+		Dock []struct {
+			ID    int64  `json:"id"`
+			Title string `json:"title"`
+			Name  string `json:"name"`
+			URL   string `json:"url"`
+		} `json:"dock"`
+	}
+
+	if err := c.Get(path, &projectData); err != nil {
+		return nil, fmt.Errorf("failed to fetch project tools: %w", err)
+	}
+
+	// Find the vault in the dock
+	for _, tool := range projectData.Dock {
+		if tool.Name == "vault" {
+			// Get the full vault details
+			var vault Vault
+			vaultPath := fmt.Sprintf("/buckets/%s/vaults/%d.json", projectID, tool.ID)
+			if err := c.Get(vaultPath, &vault); err != nil {
+				return nil, fmt.Errorf("failed to get vault: %w", err)
+			}
+			return &vault, nil
+		}
+	}
+
+	return nil, fmt.Errorf("document vault not found for project")
+}
+
+// ListDocuments returns all documents in a vault
+func (c *Client) ListDocuments(ctx context.Context, projectID string, vaultID int64) ([]Document, error) {
+	var documents []Document
+	path := fmt.Sprintf("/buckets/%s/vaults/%d/documents.json", projectID, vaultID)
+
+	// Use paginated request to get all documents
+	pr := NewPaginatedRequest(c)
+	if err := pr.GetAll(path, &documents); err != nil {
+		return nil, fmt.Errorf("failed to list documents: %w", err)
+	}
+
+	return documents, nil
+}
+
+// GetDocument returns a specific document
+func (c *Client) GetDocument(ctx context.Context, projectID string, documentID int64) (*Document, error) {
+	var document Document
+	path := fmt.Sprintf("/buckets/%s/documents/%d.json", projectID, documentID)
+
+	if err := c.Get(path, &document); err != nil {
+		return nil, fmt.Errorf("failed to get document: %w", err)
+	}
+
+	return &document, nil
+}
+
+// CreateDocument creates a new document in a vault
+func (c *Client) CreateDocument(ctx context.Context, projectID string, vaultID int64, req DocumentCreateRequest) (*Document, error) {
+	var document Document
+	path := fmt.Sprintf("/buckets/%s/vaults/%d/documents.json", projectID, vaultID)
+
+	if err := c.Post(path, req, &document); err != nil {
+		return nil, fmt.Errorf("failed to create document: %w", err)
+	}
+
+	return &document, nil
+}
+
+// UpdateDocument updates an existing document
+func (c *Client) UpdateDocument(ctx context.Context, projectID string, documentID int64, req DocumentUpdateRequest) (*Document, error) {
+	var document Document
+	path := fmt.Sprintf("/buckets/%s/documents/%d.json", projectID, documentID)
+
+	if err := c.Put(path, req, &document); err != nil {
+		return nil, fmt.Errorf("failed to update document: %w", err)
+	}
+
+	return &document, nil
+}
+
+// DeleteDocument deletes a document
+func (c *Client) DeleteDocument(ctx context.Context, projectID string, documentID int64) error {
+	path := fmt.Sprintf("/buckets/%s/documents/%d.json", projectID, documentID)
+
+	if err := c.Delete(path); err != nil {
+		return fmt.Errorf("failed to delete document: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Implements comprehensive document management functionality for Basecamp API
- Follows existing message patterns for consistent CLI experience  
- Adds document CRUD operations with interactive editing support
- Supports Markdown to rich text conversion for seamless authoring

## Key Features
- **Document API Client**: Full CRUD operations in `internal/api/documents.go`
- **CLI Commands**: `bc4 document list|create|view|edit` with aliases (documents, doc, docs)
- **Interactive Editing**: Terminal-based document creation and editing with Markdown support
- **Multiple Input Methods**: Interactive prompts, command flags, or stdin piping
- **Rich Text Conversion**: Automatic Markdown to Basecamp rich text conversion
- **URL Support**: Document URLs can be used in place of IDs (parser already supported this)

## Implementation Details
- Follows exact patterns established by message commands for consistency
- Uses existing factory pattern for dependency injection and configuration
- Leverages existing markdown converter for rich text conversion
- Supports draft creation and vault-based document organization
- Includes comprehensive help text and usage examples

## Test Plan
- [x] Build succeeds without errors
- [x] All existing tests continue to pass
- [x] Linting passes with no issues  
- [x] Help commands display correctly
- [x] Command structure follows established patterns
- [x] Code formatting applied consistently

## Resolves
Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)