### PR TITLE
Add image support for assets in Basecamp API

### DIFF
--- a/cmd/attachments/attachments.go
+++ b/cmd/attachments/attachments.go
@@ -1,0 +1,105 @@
+package attachments
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/needmore/bc4/internal/attachments"
+	"github.com/needmore/bc4/internal/ui/tableprinter"
+)
+
+// DisplayAttachments displays a list of attachments in a formatted table
+func DisplayAttachments(htmlContent string) error {
+	atts := attachments.ParseAttachments(htmlContent)
+
+	if len(atts) == 0 {
+		fmt.Println("No attachments found.")
+		return nil
+	}
+
+	// Create table for displaying attachments
+	table := tableprinter.New(os.Stdout)
+
+	// Add headers
+	table.AddHeader("#", "FILENAME", "TYPE", "SIZE", "URL")
+
+	// Add each attachment
+	for i, att := range atts {
+		// Row number
+		table.AddField(fmt.Sprintf("%d", i+1))
+
+		// Filename/Caption
+		table.AddField(att.GetDisplayName())
+
+		// Content type
+		contentType := att.ContentType
+		if contentType == "" {
+			contentType = "unknown"
+		}
+		table.AddField(contentType)
+
+		// Size (if image, show dimensions)
+		size := "-"
+		if att.IsImage() && att.Width != "" && att.Height != "" {
+			size = fmt.Sprintf("%s×%s", att.Width, att.Height)
+		}
+		table.AddField(size)
+
+		// URL
+		url := att.URL
+		if url == "" {
+			url = att.Href
+		}
+		if url == "" {
+			url = "-"
+		}
+		table.AddField(url)
+
+		table.EndRow()
+	}
+
+	return table.Render()
+}
+
+// DisplayAttachmentsWithStyle displays attachments with styled output (for view commands)
+func DisplayAttachmentsWithStyle(htmlContent string) string {
+	atts := attachments.ParseAttachments(htmlContent)
+
+	if len(atts) == 0 {
+		return ""
+	}
+
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("8"))
+	result := fmt.Sprintf("\n%s\n", labelStyle.Render("Attachments:"))
+
+	for i, att := range atts {
+		displayName := att.GetDisplayName()
+
+		// Show type indicator
+		typeIndicator := "📎"
+		if att.IsImage() {
+			typeIndicator = "🖼️"
+		}
+
+		result += fmt.Sprintf("  %d. %s %s", i+1, typeIndicator, displayName)
+
+		// Add dimensions for images
+		if att.IsImage() && att.Width != "" && att.Height != "" {
+			result += fmt.Sprintf(" (%s×%s)", att.Width, att.Height)
+		}
+
+		result += "\n"
+
+		// Add URL if available
+		url := att.URL
+		if url == "" {
+			url = att.Href
+		}
+		if url != "" {
+			result += fmt.Sprintf("     URL: %s\n", url)
+		}
+	}
+
+	return result
+}

--- a/cmd/card/attachments.go
+++ b/cmd/card/attachments.go
@@ -1,0 +1,86 @@
+package card
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	attachmentsCmd "github.com/needmore/bc4/cmd/attachments"
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/needmore/bc4/internal/parser"
+)
+
+func newAttachmentsCmd(f *factory.Factory) *cobra.Command {
+	var accountID string
+	var projectID string
+
+	cmd := &cobra.Command{
+		Use:   "attachments [card-id or URL]",
+		Short: "List attachments for a card",
+		Long: `List all attachments (images and files) associated with a card.
+
+You can specify the card using either:
+- A numeric ID (e.g., "12345")
+- A Basecamp URL (e.g., "https://3.basecamp.com/1234567/buckets/89012345/card_tables/cards/12345")`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Apply account override if specified
+			if accountID != "" {
+				f = f.WithAccount(accountID)
+			}
+
+			// Apply project override if specified
+			if projectID != "" {
+				f = f.WithProject(projectID)
+			}
+
+			// Parse card ID (could be numeric ID or URL)
+			cardID, parsedURL, err := parser.ParseArgument(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid card ID or URL: %s", args[0])
+			}
+
+			// If a URL was parsed, override account and project IDs if provided
+			if parsedURL != nil {
+				if parsedURL.ResourceType != parser.ResourceTypeCard {
+					return fmt.Errorf("URL is not for a card: %s", args[0])
+				}
+				if parsedURL.AccountID > 0 {
+					f = f.WithAccount(strconv.FormatInt(parsedURL.AccountID, 10))
+				}
+				if parsedURL.ProjectID > 0 {
+					f = f.WithProject(strconv.FormatInt(parsedURL.ProjectID, 10))
+				}
+			}
+
+			// Get API client from factory
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			cardOps := client.Cards()
+
+			// Get resolved project ID
+			resolvedProjectID, err := f.ProjectID()
+			if err != nil {
+				return err
+			}
+
+			// Fetch the card details
+			card, err := cardOps.GetCard(f.Context(), resolvedProjectID, cardID)
+			if err != nil {
+				return fmt.Errorf("failed to get card: %w", err)
+			}
+
+			// Display attachments from the content
+			return attachmentsCmd.DisplayAttachments(card.Content)
+		},
+	}
+
+	// Add flags
+	cmd.Flags().StringVarP(&accountID, "account", "a", "", "Specify account ID")
+	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Specify project ID")
+
+	return cmd
+}

--- a/cmd/card/card.go
+++ b/cmd/card/card.go
@@ -53,5 +53,8 @@ like software bugs, design requests, or other workflow-oriented tasks.`,
 	// Step management subcommands
 	cmd.AddCommand(newStepCmd(f))
 
+	// Attachments subcommand
+	cmd.AddCommand(newAttachmentsCmd(f))
+
 	return cmd
 }

--- a/cmd/card/view.go
+++ b/cmd/card/view.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	attachmentsCmd "github.com/needmore/bc4/cmd/attachments"
 	"github.com/needmore/bc4/internal/api"
 	"github.com/needmore/bc4/internal/config"
 	"github.com/needmore/bc4/internal/factory"
@@ -217,6 +218,14 @@ You can specify the card using either:
 			// Comments count
 			if card.CommentsCount > 0 {
 				fmt.Fprintf(&buf, "Comments: %d\n", card.CommentsCount)
+			}
+
+			// Show attachments if present
+			if card.Content != "" {
+				attachmentInfo := attachmentsCmd.DisplayAttachmentsWithStyle(card.Content)
+				if attachmentInfo != "" {
+					fmt.Fprint(&buf, attachmentInfo)
+				}
 			}
 
 			// Show steps if any

--- a/cmd/todo/attachments.go
+++ b/cmd/todo/attachments.go
@@ -1,0 +1,86 @@
+package todo
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	attachmentsCmd "github.com/needmore/bc4/cmd/attachments"
+	"github.com/needmore/bc4/internal/factory"
+	"github.com/needmore/bc4/internal/parser"
+)
+
+func newAttachmentsCmd(f *factory.Factory) *cobra.Command {
+	var accountID string
+	var projectID string
+
+	cmd := &cobra.Command{
+		Use:   "attachments [todo-id or URL]",
+		Short: "List attachments for a todo",
+		Long: `List all attachments (images and files) associated with a todo.
+
+You can specify the todo using either:
+- A numeric ID (e.g., "12345")
+- A Basecamp URL (e.g., "https://3.basecamp.com/1234567/buckets/89012345/todos/12345")`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Apply account override if specified
+			if accountID != "" {
+				f = f.WithAccount(accountID)
+			}
+
+			// Apply project override if specified
+			if projectID != "" {
+				f = f.WithProject(projectID)
+			}
+
+			// Parse todo ID (could be numeric ID or URL)
+			todoID, parsedURL, err := parser.ParseArgument(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid todo ID or URL: %s", args[0])
+			}
+
+			// If a URL was parsed, override account and project IDs if provided
+			if parsedURL != nil {
+				if parsedURL.ResourceType != parser.ResourceTypeTodo {
+					return fmt.Errorf("URL is not for a todo: %s", args[0])
+				}
+				if parsedURL.AccountID > 0 {
+					f = f.WithAccount(strconv.FormatInt(parsedURL.AccountID, 10))
+				}
+				if parsedURL.ProjectID > 0 {
+					f = f.WithProject(strconv.FormatInt(parsedURL.ProjectID, 10))
+				}
+			}
+
+			// Get API client from factory
+			client, err := f.ApiClient()
+			if err != nil {
+				return err
+			}
+			todoOps := client.Todos()
+
+			// Get resolved project ID
+			resolvedProjectID, err := f.ProjectID()
+			if err != nil {
+				return err
+			}
+
+			// Fetch the todo details
+			todo, err := todoOps.GetTodo(f.Context(), resolvedProjectID, todoID)
+			if err != nil {
+				return fmt.Errorf("failed to get todo: %w", err)
+			}
+
+			// Display attachments from the description
+			return attachmentsCmd.DisplayAttachments(todo.Description)
+		},
+	}
+
+	// Add flags
+	cmd.Flags().StringVarP(&accountID, "account", "a", "", "Specify account ID")
+	cmd.Flags().StringVarP(&projectID, "project", "p", "", "Specify project ID")
+
+	return cmd
+}

--- a/cmd/todo/todo.go
+++ b/cmd/todo/todo.go
@@ -39,6 +39,7 @@ Examples:
 	cmd.AddCommand(newCreateListCmd(f))
 	cmd.AddCommand(newCreateGroupCmd(f))
 	cmd.AddCommand(newRepositionGroupCmd(f))
+	cmd.AddCommand(newAttachmentsCmd(f))
 
 	return cmd
 }

--- a/cmd/todo/view.go
+++ b/cmd/todo/view.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 
+	attachmentsCmd "github.com/needmore/bc4/cmd/attachments"
 	"github.com/needmore/bc4/internal/cmdutil"
 	"github.com/needmore/bc4/internal/factory"
 	"github.com/needmore/bc4/internal/parser"
@@ -232,6 +233,14 @@ bc4 todo view 12345 --with-comments`,
 			if todo.TodolistID > 0 {
 				fmt.Fprintln(&buf)
 				fmt.Fprintf(&buf, "%s %d\n", labelStyle.Render("Todo List ID:"), todo.TodolistID)
+			}
+
+			// Show attachments if present
+			if todo.Description != "" {
+				attachmentInfo := attachmentsCmd.DisplayAttachmentsWithStyle(todo.Description)
+				if attachmentInfo != "" {
+					fmt.Fprint(&buf, attachmentInfo)
+				}
 			}
 
 			// Show timestamps

--- a/internal/attachments/parser.go
+++ b/internal/attachments/parser.go
@@ -1,0 +1,81 @@
+package attachments
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Attachment represents a Basecamp attachment with metadata
+type Attachment struct {
+	SGID        string
+	ContentType string
+	Filename    string
+	URL         string
+	Href        string
+	Width       string
+	Height      string
+	Caption     string
+}
+
+// ParseAttachments extracts all bc-attachment elements from HTML content
+func ParseAttachments(htmlContent string) []Attachment {
+	var attachments []Attachment
+
+	// Regular expression to match bc-attachment tags with their attributes
+	// This handles both self-closing and non-self-closing tags
+	// (?s) enables DOTALL mode so . matches newlines
+	bcAttachmentPattern := `(?s)<bc-attachment([^>]*)(?:>.*?</bc-attachment>|/>)`
+	re := regexp.MustCompile(bcAttachmentPattern)
+
+	matches := re.FindAllStringSubmatch(htmlContent, -1)
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+
+		attrs := match[1]
+		attachment := Attachment{
+			SGID:        extractAttribute(attrs, "sgid"),
+			ContentType: extractAttribute(attrs, "content-type"),
+			Filename:    extractAttribute(attrs, "filename"),
+			URL:         extractAttribute(attrs, "url"),
+			Href:        extractAttribute(attrs, "href"),
+			Width:       extractAttribute(attrs, "width"),
+			Height:      extractAttribute(attrs, "height"),
+			Caption:     extractAttribute(attrs, "caption"),
+		}
+
+		attachments = append(attachments, attachment)
+	}
+
+	return attachments
+}
+
+// extractAttribute extracts the value of an HTML attribute from a string
+func extractAttribute(attrs, attrName string) string {
+	// Pattern to match attribute="value" or attribute='value'
+	pattern := attrName + `\s*=\s*["']([^"']*)["']`
+	re := regexp.MustCompile(pattern)
+	matches := re.FindStringSubmatch(attrs)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return ""
+}
+
+// IsImage returns true if the attachment is an image based on its content type
+func (a *Attachment) IsImage() bool {
+	return strings.HasPrefix(a.ContentType, "image/")
+}
+
+// GetDisplayName returns the best display name for the attachment
+func (a *Attachment) GetDisplayName() string {
+	if a.Caption != "" {
+		return a.Caption
+	}
+	if a.Filename != "" {
+		return a.Filename
+	}
+	return "Unnamed attachment"
+}

--- a/internal/attachments/parser_test.go
+++ b/internal/attachments/parser_test.go
@@ -1,0 +1,142 @@
+package attachments
+
+import (
+	"testing"
+)
+
+func TestParseAttachments(t *testing.T) {
+	tests := []struct {
+		name     string
+		html     string
+		expected int
+		checkFn  func(*testing.T, []Attachment)
+	}{
+		{
+			name: "single image attachment",
+			html: `<bc-attachment sgid="BAh7CEkiCG..." content-type="image/jpeg" width="2560" height="1536" url="https://example.com/image.jpg" href="https://example.com/image.jpg" filename="my-photo.jpg" caption="My photo">
+  <figure>
+    <img srcset="..." src="...">
+    <figcaption>My photo</figcaption>
+  </figure>
+</bc-attachment>`,
+			expected: 1,
+			checkFn: func(t *testing.T, attachments []Attachment) {
+				if len(attachments) != 1 {
+					t.Fatalf("expected 1 attachment, got %d", len(attachments))
+				}
+				a := attachments[0]
+				if a.SGID != "BAh7CEkiCG..." {
+					t.Errorf("expected SGID 'BAh7CEkiCG...', got '%s'", a.SGID)
+				}
+				if a.ContentType != "image/jpeg" {
+					t.Errorf("expected content-type 'image/jpeg', got '%s'", a.ContentType)
+				}
+				if a.Filename != "my-photo.jpg" {
+					t.Errorf("expected filename 'my-photo.jpg', got '%s'", a.Filename)
+				}
+				if a.Caption != "My photo" {
+					t.Errorf("expected caption 'My photo', got '%s'", a.Caption)
+				}
+				if !a.IsImage() {
+					t.Error("expected IsImage() to return true")
+				}
+			},
+		},
+		{
+			name: "multiple attachments",
+			html: `<div>
+  <bc-attachment presentation="gallery" sgid="SGIDone" content-type="image/png" filename="first.png" url="https://example.com/first.png"></bc-attachment>
+  <bc-attachment presentation="gallery" sgid="SGIDtwo" content-type="image/gif" filename="second.gif" url="https://example.com/second.gif"></bc-attachment>
+</div>`,
+			expected: 2,
+			checkFn: func(t *testing.T, attachments []Attachment) {
+				if len(attachments) != 2 {
+					t.Fatalf("expected 2 attachments, got %d", len(attachments))
+				}
+				if attachments[0].Filename != "first.png" {
+					t.Errorf("expected first filename 'first.png', got '%s'", attachments[0].Filename)
+				}
+				if attachments[1].Filename != "second.gif" {
+					t.Errorf("expected second filename 'second.gif', got '%s'", attachments[1].Filename)
+				}
+			},
+		},
+		{
+			name: "self-closing tag",
+			html: `<bc-attachment sgid="TEST123" content-type="application/pdf" filename="document.pdf" url="https://example.com/doc.pdf" />`,
+			expected: 1,
+			checkFn: func(t *testing.T, attachments []Attachment) {
+				if len(attachments) != 1 {
+					t.Fatalf("expected 1 attachment, got %d", len(attachments))
+				}
+				a := attachments[0]
+				if a.ContentType != "application/pdf" {
+					t.Errorf("expected content-type 'application/pdf', got '%s'", a.ContentType)
+				}
+				if a.IsImage() {
+					t.Error("expected IsImage() to return false for PDF")
+				}
+			},
+		},
+		{
+			name:     "no attachments",
+			html:     `<p>Just some regular HTML content</p>`,
+			expected: 0,
+			checkFn: func(t *testing.T, attachments []Attachment) {
+				if len(attachments) != 0 {
+					t.Fatalf("expected 0 attachments, got %d", len(attachments))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attachments := ParseAttachments(tt.html)
+			if len(attachments) != tt.expected {
+				t.Errorf("expected %d attachments, got %d", tt.expected, len(attachments))
+			}
+			if tt.checkFn != nil {
+				tt.checkFn(t, attachments)
+			}
+		})
+	}
+}
+
+func TestGetDisplayName(t *testing.T) {
+	tests := []struct {
+		name       string
+		attachment Attachment
+		expected   string
+	}{
+		{
+			name: "with caption",
+			attachment: Attachment{
+				Caption:  "My Caption",
+				Filename: "file.jpg",
+			},
+			expected: "My Caption",
+		},
+		{
+			name: "without caption, with filename",
+			attachment: Attachment{
+				Filename: "document.pdf",
+			},
+			expected: "document.pdf",
+		},
+		{
+			name:       "no caption or filename",
+			attachment: Attachment{},
+			expected:   "Unnamed attachment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.attachment.GetDisplayName()
+			if result != tt.expected {
+				t.Errorf("expected '%s', got '%s'", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement functionality to parse and display attachments (images and files) that are embedded in todo descriptions and card content via Basecamp's bc-attachment HTML tags.

Changes:
- Add internal/attachments package with parser for bc-attachment tags
- Add 'bc4 todo attachments <id>' command to list todo attachments
- Add 'bc4 card attachments <id>' command to list card attachments
- Update 'bc4 todo view' to display attachment information
- Update 'bc4 card view' to display attachment information
- Add comprehensive tests for attachment parsing

The parser extracts attachment metadata including:
- Filename and caption
- Content type (image/*, application/*, etc.)
- Direct download URLs
- Image dimensions (for image attachments)

This addresses the issue where users could not see images attached to assets like cards or todos through the CLI.