### PR TITLE
feat(message): show pinned status in list and sort pinned first

### DIFF
--- a/cmd/message/list_test.go
+++ b/cmd/message/list_test.go
@@ -88,4 +88,9 @@ func TestListCmdFlags(t *testing.T) {
 	assert.NotNil(t, limitFlag)
 	assert.Equal(t, "l", limitFlag.Shorthand)
 	assert.Equal(t, "Limit number of messages shown", limitFlag.Usage)
+
+	// Test no-pin-sort flag
+	noPinSortFlag := cmd.Flag("no-pin-sort")
+	assert.NotNil(t, noPinSortFlag)
+	assert.Equal(t, "Don't sort pinned messages first", noPinSortFlag.Usage)
 }


### PR DESCRIPTION
## Summary

- Sort pinned messages first by default when listing messages
- Show pinned indicator in message list output:
  - TTY mode: `* ` prefix before subject
  - Non-TTY mode: `PINNED` column with true/false
- Add `--no-pin-sort` flag to disable pinned-first sorting

## Usage

```bash
# List messages (pinned first by default)
bc4 message list

# List without pinned sorting
bc4 message list --no-pin-sort
```

## Test plan

- [ ] Verify pinned messages appear first in list
- [ ] Verify `* ` prefix shows for pinned messages in terminal
- [ ] Verify `--no-pin-sort` disables the sorting
- [ ] Verify PINNED column appears in non-TTY output

🤖 Generated with [Claude Code](https://claude.com/claude-code)