### PR TITLE
fix(todo): add --account and --project flags to check, uncheck, and comment create commands

### DIFF
--- a/cmd/comment/create.go
+++ b/cmd/comment/create.go
@@ -62,8 +62,13 @@ You can provide comment content in several ways:
 					return fmt.Errorf("invalid Basecamp URL: %w", err)
 				}
 				recordingID = parsed.ResourceID
-				projectID = strconv.FormatInt(parsed.ProjectID, 10)
-				// Override factory with URL-provided account/project if not already set
+				// Use flag value if provided, otherwise use URL's project ID
+				if projectIDFlag != "" {
+					projectID = projectIDFlag
+				} else {
+					projectID = strconv.FormatInt(parsed.ProjectID, 10)
+				}
+				// Override factory with URL-provided account if flag not set
 				if accountID == "" && parsed.AccountID > 0 {
 					f = f.WithAccount(strconv.FormatInt(parsed.AccountID, 10))
 				}

--- a/cmd/todo/check.go
+++ b/cmd/todo/check.go
@@ -43,7 +43,7 @@ You can specify the todo using either:
 				f = f.WithProject(projectID)
 			}
 
-			return runCheck(f, args[0])
+			return runCheck(f, args[0], accountID, projectID)
 		},
 	}
 
@@ -53,7 +53,7 @@ You can specify the todo using either:
 	return cmd
 }
 
-func runCheck(f *factory.Factory, todoIDStr string) error {
+func runCheck(f *factory.Factory, todoIDStr string, accountIDFlag string, projectIDFlag string) error {
 	// Parse todo ID (handle #123 format and URLs)
 	todoIDStr = strings.TrimPrefix(todoIDStr, "#")
 	todoID, parsedURL, err := parser.ParseArgument(todoIDStr)
@@ -61,15 +61,16 @@ func runCheck(f *factory.Factory, todoIDStr string) error {
 		return fmt.Errorf("invalid todo ID or URL: %s", todoIDStr)
 	}
 
-	// If a URL was parsed, override account and project IDs if provided
+	// If a URL was parsed, use URL values only if flags weren't provided
 	if parsedURL != nil {
 		if parsedURL.ResourceType != parser.ResourceTypeTodo {
 			return fmt.Errorf("URL is not for a todo: %s", todoIDStr)
 		}
-		if parsedURL.AccountID > 0 {
+		// Only use URL values if corresponding flags weren't set
+		if accountIDFlag == "" && parsedURL.AccountID > 0 {
 			f = f.WithAccount(strconv.FormatInt(parsedURL.AccountID, 10))
 		}
-		if parsedURL.ProjectID > 0 {
+		if projectIDFlag == "" && parsedURL.ProjectID > 0 {
 			f = f.WithProject(strconv.FormatInt(parsedURL.ProjectID, 10))
 		}
 	}

--- a/cmd/todo/uncheck.go
+++ b/cmd/todo/uncheck.go
@@ -42,7 +42,7 @@ You can specify the todo using either:
 				f = f.WithProject(projectID)
 			}
 
-			return runUncheck(f, args[0])
+			return runUncheck(f, args[0], accountID, projectID)
 		},
 	}
 
@@ -52,7 +52,7 @@ You can specify the todo using either:
 	return cmd
 }
 
-func runUncheck(f *factory.Factory, todoIDStr string) error {
+func runUncheck(f *factory.Factory, todoIDStr string, accountIDFlag string, projectIDFlag string) error {
 	// Parse todo ID (handle #123 format and URLs)
 	todoIDStr = strings.TrimPrefix(todoIDStr, "#")
 	todoID, parsedURL, err := parser.ParseArgument(todoIDStr)
@@ -60,15 +60,16 @@ func runUncheck(f *factory.Factory, todoIDStr string) error {
 		return fmt.Errorf("invalid todo ID or URL: %s", todoIDStr)
 	}
 
-	// If a URL was parsed, override account and project IDs if provided
+	// If a URL was parsed, use URL values only if flags weren't provided
 	if parsedURL != nil {
 		if parsedURL.ResourceType != parser.ResourceTypeTodo {
 			return fmt.Errorf("URL is not for a todo: %s", todoIDStr)
 		}
-		if parsedURL.AccountID > 0 {
+		// Only use URL values if corresponding flags weren't set
+		if accountIDFlag == "" && parsedURL.AccountID > 0 {
 			f = f.WithAccount(strconv.FormatInt(parsedURL.AccountID, 10))
 		}
-		if parsedURL.ProjectID > 0 {
+		if projectIDFlag == "" && parsedURL.ProjectID > 0 {
 			f = f.WithProject(strconv.FormatInt(parsedURL.ProjectID, 10))
 		}
 	}


### PR DESCRIPTION
Commands like `todo check`, `todo uncheck`, and `comment create` were missing
the `--account` and `--project` flags that other commands have. When users
passed these flags, they were silently accepted by the root command's persistent
flags but never read by the commands, causing them to use default account/project
values instead. This resulted in "todo not found" errors when the defaults
didn't match the todo's actual location.

Fixes #109