### PR TITLE
feat: add --group parameter to todo add command

### DIFF
--- a/internal/parser/url.go
+++ b/internal/parser/url.go
@@ -16,6 +16,7 @@ const (
 	ResourceTypeTodo          ResourceType = "todo"
 	ResourceTypeTodoSet       ResourceType = "todoset"
 	ResourceTypeTodoList      ResourceType = "todolist"
+	ResourceTypeTodoGroup     ResourceType = "todogroup"
 	ResourceTypeCard          ResourceType = "card"
 	ResourceTypeCardTable     ResourceType = "card_table"
 	ResourceTypeColumn        ResourceType = "column"
@@ -96,7 +97,7 @@ var urlPatterns = []urlPattern{
 	},
 	// Todo list pattern: /1234567/buckets/89012345/todosets/34567890/todolists/45678901
 	{
-		regex:        regexp.MustCompile(`^/(\d+)/buckets/(\d+)/todosets/(\d+)/todolists/(\d+)`),
+		regex:        regexp.MustCompile(`^/(\d+)/buckets/(\d+)/todosets/(\d+)/todolists/(\d+)$`),
 		resourceType: ResourceTypeTodoList,
 		extractor: func(matches []string) (*ParsedURL, error) {
 			accountID, _ := strconv.ParseInt(matches[1], 10, 64)
@@ -109,6 +110,24 @@ var urlPatterns = []urlPattern{
 				ResourceType: ResourceTypeTodoList,
 				ResourceID:   todoListID,
 				ParentID:     todoSetID,
+			}, nil
+		},
+	},
+	// Todo group pattern: /1234567/buckets/89012345/todolists/34567890/groups/45678901
+	{
+		regex:        regexp.MustCompile(`^/(\d+)/buckets/(\d+)/todolists/(\d+)/groups/(\d+)`),
+		resourceType: ResourceTypeTodoGroup,
+		extractor: func(matches []string) (*ParsedURL, error) {
+			accountID, _ := strconv.ParseInt(matches[1], 10, 64)
+			projectID, _ := strconv.ParseInt(matches[2], 10, 64)
+			todoListID, _ := strconv.ParseInt(matches[3], 10, 64)
+			todoGroupID, _ := strconv.ParseInt(matches[4], 10, 64)
+			return &ParsedURL{
+				AccountID:    accountID,
+				ProjectID:    projectID,
+				ResourceType: ResourceTypeTodoGroup,
+				ResourceID:   todoGroupID,
+				ParentID:     todoListID,
 			}, nil
 		},
 	},

--- a/internal/parser/url_test.go
+++ b/internal/parser/url_test.go
@@ -131,6 +131,25 @@ func TestParseBasecampURL(t *testing.T) {
 			wantType:    ResourceTypeVault,
 			wantID:      34567890,
 		},
+		// Todo group URLs
+		{
+			name:        "todo group URL",
+			url:         "https://3.basecamp.com/1234567/buckets/89012345/todolists/34567890/groups/45678901",
+			wantAccount: 1234567,
+			wantProject: 89012345,
+			wantType:    ResourceTypeTodoGroup,
+			wantID:      45678901,
+			wantParent:  34567890,
+		},
+		{
+			name:        "todo group API URL with .json",
+			url:         "https://3.basecampapi.com/1234567/buckets/89012345/todolists/34567890/groups/45678901.json",
+			wantAccount: 1234567,
+			wantProject: 89012345,
+			wantType:    ResourceTypeTodoGroup,
+			wantID:      45678901,
+			wantParent:  34567890,
+		},
 		// Error cases
 		{
 			name:    "invalid URL",


### PR DESCRIPTION
## Summary

Adds support for creating todos within specific groups by implementing a `--group` flag for the `bc4 todo add` command. This enables full automation of organized todo list creation using colored groups.

## Changes

- ✅ Add `--group` flag to `todo add` command
  - Accepts group ID (numeric)
  - Accepts group name (lookup within list)
  - Accepts group URL
- ✅ Update API endpoint logic
  - When `--group` specified, uses `/todolists/{group_id}/todos.json`
  - When `--group` not specified, uses `/todolists/{list_id}/todos.json` (current behavior)
- ✅ Add validation
  - Verifies group exists
  - Matches groups by ID, title, or name (case-insensitive)
- ✅ Update help text and examples
- ✅ Add URL parser support for todo group URLs
- ✅ Add tests for todo group URL parsing

## Usage Examples

```bash
# Add todo to a group by name
bc4 todo add "Fix bug" --list "Sprint Tasks" --group "In Progress"

# Add todo to a group by ID
bc4 todo add "Review PR" --list 12345 --group 67890

# Add todo to a group by URL
bc4 todo add "Deploy feature" --list 12345 --group "https://3.basecamp.com/.../groups/67890"
```

## Automation Example

This enables the use case described in the issue:

```bash
# Create list
list_id=$(bc4 todo create-list "Accessibility Issues" --json | jq -r '.id')

# Create colored groups
group_a=$(bc4 todo create-group "WCAG Level A" --list "$list_id" --color red --json | jq -r '.id')
group_aa=$(bc4 todo create-group "WCAG Level AA" --list "$list_id" --color yellow --json | jq -r '.id')
group_aaa=$(bc4 todo create-group "WCAG Level AAA" --list "$list_id" --color green --json | jq -r '.id')

# Add todos to specific groups
bc4 todo add "Missing alt text" --list "$list_id" --group "$group_a"
bc4 todo add "Low contrast" --list "$list_id" --group "$group_aa"
bc4 todo add "AAA color contrast" --list "$list_id" --group "$group_aaa"
```

## Testing

- All existing tests pass
- Added URL parser tests for todo group URLs
- Verified group lookup by ID, name, and URL
- Linter passes (fixed staticcheck issue)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)