### PR TITLE
fix: use atomic file writes to prevent auth/config corruption

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/needmore/bc4/internal/utils"
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
 
@@ -504,5 +505,5 @@ func (c *Client) saveAuthStore() error {
 		return err
 	}
 
-	return os.Rename(tmpPath, c.storePath)
+	return utils.AtomicRename(tmpPath, c.storePath)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/needmore/bc4/internal/utils"
 	"github.com/spf13/viper"
 )
 
@@ -126,7 +127,7 @@ func Save(config *Config) error {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
-	if err := os.Rename(tmpPath, configPath); err != nil {
+	if err := utils.AtomicRename(tmpPath, configPath); err != nil {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to save config file: %w", err)
 	}

--- a/internal/utils/fileutil.go
+++ b/internal/utils/fileutil.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"os"
+	"runtime"
+)
+
+// AtomicRename renames src to dst atomically where possible.
+// On POSIX systems os.Rename replaces an existing dst atomically.
+// On Windows os.Rename fails when dst already exists, so we remove
+// the destination first and then rename. This leaves a small window
+// where dst doesn't exist, but it prevents silent failures that would
+// strand the temp file and leave the old config in place.
+func AtomicRename(src, dst string) error {
+	if runtime.GOOS == "windows" {
+		// Remove the destination so os.Rename can succeed.
+		// Ignore the error – the file may not exist yet.
+		_ = os.Remove(dst)
+	}
+	return os.Rename(src, dst)
+}


### PR DESCRIPTION
When a network failure or process interruption occurs during a file
write, the O_TRUNC flag causes the file to be emptied before the new
content is written. This can leave auth.json or config.json empty or
partially written, causing "Authentication failed" and "OAuth
credentials not configured" errors on subsequent runs.

Changes:
- Use temp file + rename pattern for atomic writes in both
  saveAuthStore() and config.Save()
- Add JSON decode error handling in loadAuthStore() to detect
  corrupted files instead of silently using empty state
- Surface saveAuthStore() errors during token refresh instead of
  silently ignoring them

Fixes #133

https://claude.ai/code/session_01RGrBwVCw4fyCR33RmTWAZ4